### PR TITLE
Confirm before applying if editing data is not same as primary data.

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
@@ -258,10 +258,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
 
                     // If the primary data is not the same as the editing data, ask the user to confirm.
                     // If the user confirms, remove the primary data and apply the editing data.
-                    const string dialogTitle = "Confirm";
                     var dialogMessage =
                         $"The {nameof(projectSettings.PrimaryData)} of the Project Settings is not the same as the data you are applying. Do you want to remove the {nameof(projectSettings.PrimaryData)} from Project Settings and apply the editing data?";
-                    if (EditorUtility.DisplayDialog(dialogTitle, dialogMessage, "Remove & Apply", "Cancel"))
+                    if (EditorUtility.DisplayDialog("Confirm", dialogMessage, "Remove & Apply", "Cancel"))
                     {
                         projectSettings.PrimaryData = null;
                         Apply();


### PR DESCRIPTION
* エディタから Apply を行う際に、その Layout Data が Project Settings に設定している Primary Data（自動適用対象データ）と異なる場合に確認ダイアログを表示するように修正