### PR TITLE
ObjectFilterの対象がフォルダの時にフォルダ名を含んだ別フォルダやアセットを含んでしまう問題の修正

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
@@ -64,7 +64,7 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                 if (objectIsFolder)
                 {
                     var isInclusion = !isSelf && !isFolder &&
-                                      assetPath.StartsWith(objectAssetPath, StringComparison.Ordinal);
+                                      assetPath.StartsWith(objectAssetPath + "/", StringComparison.Ordinal);
                     switch (FolderTargetingMode)
                     {
                         case FolderTargetingMode.IncludedNonFolderAssets:
@@ -72,11 +72,11 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                                 return true;
                             break;
                         case FolderTargetingMode.Self:
-                            if (isSelf)
+                            if (isSelf && isFolder)
                                 return true;
                             break;
                         case FolderTargetingMode.Both:
-                            if (isInclusion || isSelf)
+                            if (isInclusion || (isSelf && isFolder))
                                 return true;
                             break;
                         default:

--- a/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilter.cs
@@ -64,7 +64,7 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                 if (objectIsFolder)
                 {
                     var isInclusion = !isSelf && !isFolder &&
-                                      assetPath.StartsWith(objectAssetPath + "/", StringComparison.Ordinal);
+                                      assetPath.StartsWith(objectAssetPath, StringComparison.Ordinal);
                     switch (FolderTargetingMode)
                     {
                         case FolderTargetingMode.IncludedNonFolderAssets:
@@ -72,11 +72,11 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                                 return true;
                             break;
                         case FolderTargetingMode.Self:
-                            if (isSelf && isFolder)
+                            if (isSelf)
                                 return true;
                             break;
                         case FolderTargetingMode.Both:
-                            if (isInclusion || (isSelf && isFolder))
+                            if (isInclusion || isSelf)
                                 return true;
                             break;
                         default:

--- a/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
@@ -40,6 +40,25 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
         }
 
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
+        public bool IsMatch_ObjectIsFolder_ContainsFilterDirectoryName_ReturnFalse(FolderTargetingMode targetingMode, string relativeAssetPath, Type assetType)
+        {
+            var filter = new ObjectBasedAssetFilter();
+            filter.FolderTargetingMode = targetingMode;
+            filter.Object.Value = AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder);
+            filter.SetupForMatching();
+            var assetPath = TestAssetPaths.CreateAbsoluteAssetPath(relativeAssetPath);
+            return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
+        }
+
         [Test]
         public void IsMatch_RegisterNotMatchedObject_ReturnFalse()
         {
@@ -69,6 +88,16 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Shared.Texture256));
             filter.SetupForMatching();
             Assert.That(filter.IsMatch(TestAssetPaths.Shared.Texture64, typeof(Texture2D), false), Is.False);
+        }
+        
+        [Test]
+        public void IsMatch_AnotherDirectoryContainsFilterDirectoryName_ReturnFalse()
+        {
+            var filter = new ObjectBasedAssetFilter();
+            filter.Object.IsListMode = true;
+            filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder));
+            filter.SetupForMatching();
+            Assert.That(filter.IsMatch(TestAssetPaths.Dummy1.PrefabDummy, typeof(GameObject), false), Is.False);
         }
     }
 }

--- a/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/ObjectBasedAssetFilterTest.cs
@@ -40,25 +40,6 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
         }
 
-        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.IncludedNonFolderAssets, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Self, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.Folder, typeof(DefaultAsset), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.Dummy1.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        [TestCase(FolderTargetingMode.Both, TestAssetRelativePaths.PrefabDummy, typeof(GameObject), ExpectedResult = false)]
-        public bool IsMatch_ObjectIsFolder_ContainsFilterDirectoryName_ReturnFalse(FolderTargetingMode targetingMode, string relativeAssetPath, Type assetType)
-        {
-            var filter = new ObjectBasedAssetFilter();
-            filter.FolderTargetingMode = targetingMode;
-            filter.Object.Value = AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder);
-            filter.SetupForMatching();
-            var assetPath = TestAssetPaths.CreateAbsoluteAssetPath(relativeAssetPath);
-            return filter.IsMatch(assetPath, assetType, assetType == typeof(DefaultAsset));
-        }
-
         [Test]
         public void IsMatch_RegisterNotMatchedObject_ReturnFalse()
         {
@@ -88,16 +69,6 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Shared.AssetGroups.AssetFilter
             filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Shared.Texture256));
             filter.SetupForMatching();
             Assert.That(filter.IsMatch(TestAssetPaths.Shared.Texture64, typeof(Texture2D), false), Is.False);
-        }
-        
-        [Test]
-        public void IsMatch_AnotherDirectoryContainsFilterDirectoryName_ReturnFalse()
-        {
-            var filter = new ObjectBasedAssetFilter();
-            filter.Object.IsListMode = true;
-            filter.Object.AddValue(AssetDatabase.LoadAssetAtPath<Object>(TestAssetPaths.Dummy.Folder));
-            filter.SetupForMatching();
-            Assert.That(filter.IsMatch(TestAssetPaths.Dummy1.PrefabDummy, typeof(GameObject), false), Is.False);
         }
     }
 }

--- a/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
@@ -10,6 +10,7 @@ namespace SmartAddresser.Tests.Editor.Core
 {
     public static class TestAssetRelativePaths
     {
+        public const string PrefabDummy = "Dummy";
         public static class Shared
         {
             public const string Folder = "Shared";
@@ -24,6 +25,12 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public const string Folder = "Dummy";
             public const string PrefabDummy = Folder + "/prefab_dummy.prefab";
+        }
+        
+        public static class Dummy1
+        {
+            public const string Folder = "Dummy1";
+            public const string PrefabDummy = Folder + "/prefab_dummy_1.prefab";
         }
     }
 
@@ -50,6 +57,7 @@ namespace SmartAddresser.Tests.Editor.Core
             return $"{Folder}/{relativeAssetPath}";
         }
 
+        public static string DummyPrefab => CreateAbsoluteAssetPath(TestAssetRelativePaths.PrefabDummy);
         public static class Shared
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Shared.Folder);
@@ -64,6 +72,12 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.Folder);
             public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.PrefabDummy);
+        }
+
+        public static class Dummy1
+        {
+            public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.Folder);
+            public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.PrefabDummy);
         }
     }
 }

--- a/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/TestAssetPaths.cs
@@ -10,7 +10,6 @@ namespace SmartAddresser.Tests.Editor.Core
 {
     public static class TestAssetRelativePaths
     {
-        public const string PrefabDummy = "Dummy";
         public static class Shared
         {
             public const string Folder = "Shared";
@@ -25,12 +24,6 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public const string Folder = "Dummy";
             public const string PrefabDummy = Folder + "/prefab_dummy.prefab";
-        }
-        
-        public static class Dummy1
-        {
-            public const string Folder = "Dummy1";
-            public const string PrefabDummy = Folder + "/prefab_dummy_1.prefab";
         }
     }
 
@@ -57,7 +50,6 @@ namespace SmartAddresser.Tests.Editor.Core
             return $"{Folder}/{relativeAssetPath}";
         }
 
-        public static string DummyPrefab => CreateAbsoluteAssetPath(TestAssetRelativePaths.PrefabDummy);
         public static class Shared
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Shared.Folder);
@@ -72,12 +64,6 @@ namespace SmartAddresser.Tests.Editor.Core
         {
             public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.Folder);
             public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy.PrefabDummy);
-        }
-
-        public static class Dummy1
-        {
-            public static string Folder => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.Folder);
-            public static string PrefabDummy => CreateAbsoluteAssetPath(TestAssetRelativePaths.Dummy1.PrefabDummy);
         }
     }
 }

--- a/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy.prefab
+++ b/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy.prefab
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9143126877741232634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6003330914821437726}
+  m_Layer: 0
+  m_Name: Dummy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6003330914821437726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9143126877741232634}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy.prefab.meta
+++ b/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f53ee30a9e600454898228229ee0481c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1.meta
+++ b/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74e1960632d4d09408b78786e655d47e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1/prefab_dummy_1.prefab
+++ b/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1/prefab_dummy_1.prefab
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9143126877741232634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6003330914821437726}
+  m_Layer: 0
+  m_Name: prefab_dummy_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6003330914821437726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9143126877741232634}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1/prefab_dummy_1.prefab.meta
+++ b/Assets/SmartAddresser/Tests/Editor/TestAssets/Dummy1/prefab_dummy_1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 441d6a4418867364abf17c4c1335cedb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
#44 の修正を行います。
これに伴って、以下のテストを追加しました。

+ ObjectFilterの対象と同名のアセット(非フォルダ)が含まれる場合
+ ObjectFilterの対象と同じ名前を含んだ同じ階層にある別のディレクトリが対象の場合
+ ObjectFilterの対象と同じ名前を含んだ同じ階層にある別のディレクトリ以下に存在するアセットが対象の場合

## セルフレビュー項目
- [x] 同じ名称を含むディレクトリが対象にならない
- [x] 同じ階層にある同じ名前のプレハブが対象にならない
- [x] テスト通過
- [x] テスト用アセットとmetaのコミット漏れがない

## 他
Fork先でrevertを行った都合でコミット履歴が汚れています。
必要があれば別途ブランチを切りなおします