### PR TITLE
Add sortByAssetPaths feature

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
@@ -12,6 +12,7 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
         [SerializeField] private LayoutRuleData primaryData;
         [SerializeField] private MonoScript versionExpressionParser;
         [SerializeField] private Validation validation = new Validation();
+        [SerializeField] private bool sortByAssetPaths = false;
 
         public LayoutRuleData PrimaryData
         {
@@ -49,6 +50,19 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
 
                 validation = value;
                 Save(true);
+            }
+        }
+
+        public bool SortByAssetPaths
+        {
+            get => sortByAssetPaths;
+            set
+            {
+                if (value == sortByAssetPaths)
+                    return;
+
+                sortByAssetPaths = value;
+                Save(true);    
             }
         }
 

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
@@ -82,6 +82,13 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
                         projectSettings.ValidationSettings = new SmartAddresserProjectSettings.Validation(duplicateAddresses,
                             duplicateAssetPaths, entryHasMultipleVersions);
                 }
+
+                using (var ccs = new EditorGUI.ChangeCheckScope())
+                {
+                    var sortByAssetPaths = EditorGUILayout.Toggle("Sort by assetPaths", projectSettings.SortByAssetPaths);
+                    if (ccs.changed)
+                        projectSettings.SortByAssetPaths = sortByAssetPaths;
+                }
             }
         }
 

--- a/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using SmartAddresser.Editor.Core.Tools.Shared;
 using UnityEditor;
 
 namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
@@ -7,7 +8,14 @@ namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
     {
         public string[] GetAllAssetPaths()
         {
-            return AssetDatabase.GetAllAssetPaths();
+            string[] allAssetPaths = AssetDatabase.GetAllAssetPaths();
+            var projectSettings = SmartAddresserProjectSettings.instance;
+            if (projectSettings == null || !projectSettings.SortByAssetPaths)
+            {
+                return allAssetPaths;
+            }
+            Array.Sort(allAssetPaths);
+            return allAssetPaths;
         }
 
         public string GUIDToAssetPath(string guid)

--- a/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
@@ -14,7 +14,7 @@ namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
             {
                 return allAssetPaths;
             }
-            Array.Sort(allAssetPaths);
+            Array.Sort(allAssetPaths, StringComparer.OrdinalIgnoreCase);
             return allAssetPaths;
         }
 


### PR DESCRIPTION
## Introduction
Thank you for developing such a convenient library. I've been using it very comfortably.

## Issue
#49 
I noticed that when executing "Apply to Addressables" from the Layout Rule Editor Window, the order of registration depends on the asset paths returned by `AssetDatabase.GetAllAssetPaths`. This has resulted in instances where unnecessary changes appear in the Addressable Asset Groups despite no changes being made to the assets themselves.

## Proposed Solution
To address this, I propose the addition of a `SortByAssetPaths` toggle in the Project Settings. When this option is enabled, it would sort the results of `AssetDatabase.GetAllAssetPaths` to ensure a consistent ordering of assets.

## Implementation
I have implemented this feature with the considerations for existing projects in mind, setting the default state of `SortByAssetPaths` to Off to avoid any unexpected changes to the current workflow.

## Request
I would be grateful if you could review and consider the inclusion of this feature. Your feedback will be highly appreciated.

Best regards,