### PR TITLE
Keep the order of existing entries.

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -1,12 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using SmartAddresser.Editor.Core.Models.LayoutRules;
 using SmartAddresser.Editor.Foundation.AddressableAdapter;
 using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using SmartAddresser.Editor.Foundation.SemanticVersioning;
 using UnityEditor.AddressableAssets.Settings;
-using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Models.Services
 {

--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using SmartAddresser.Editor.Core.Models.LayoutRules;
 using SmartAddresser.Editor.Foundation.AddressableAdapter;
 using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using SmartAddresser.Editor.Foundation.SemanticVersioning;
+using UnityEditor.AddressableAssets.Settings;
 using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Models.Services
@@ -45,21 +48,20 @@ namespace SmartAddresser.Editor.Core.Models.Services
         {
             Setup();
 
-            // Remove all entries in the addressable groups that are under control of this layout rule.
-            var groupNames = _layoutRule
-                .AddressRules
-                .Where(x => x.Control.Value)
-                .Select(x => x.AddressableGroup.Name);
-            foreach (var groupName in groupNames)
-                _addressableSettingsAdapter.RemoveAllEntries(groupName, false);
-
             // Add all entries to the addressable asset system.
+            var removeTargetAssetGuids = new List<string>();
             var versionExpression = _layoutRule.Settings.VersionExpression;
             foreach (var assetPath in _assetDatabaseAdapter.GetAllAssetPaths())
             {
                 var guid = _assetDatabaseAdapter.AssetPathToGUID(assetPath);
-                TryAddEntry(guid, false, false, versionExpression.Value);
+                var result = TryAddEntry(guid, false, false, versionExpression.Value);
+                if (!result)
+                    removeTargetAssetGuids.Add(guid);
             }
+            
+            // Remove all entries that are not under control of this layout rule (if the entry is exists).
+            foreach (var guid in removeTargetAssetGuids)
+                _addressableSettingsAdapter.RemoveEntry(guid, false);
             
             _addressableSettingsAdapter.InvokeBatchModificationEvent();
         }

--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -5,6 +5,7 @@ using SmartAddresser.Editor.Foundation.AddressableAdapter;
 using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using UnityEditor;
 using UnityEditor.AddressableAssets;
+using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Tools.Importer
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -5,7 +5,6 @@ using SmartAddresser.Editor.Foundation.AddressableAdapter;
 using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using UnityEditor;
 using UnityEditor.AddressableAssets;
-using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Tools.Importer
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
@@ -12,7 +12,6 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
         [SerializeField] private LayoutRuleData primaryData;
         [SerializeField] private MonoScript versionExpressionParser;
         [SerializeField] private Validation validation = new Validation();
-        [SerializeField] private bool sortByAssetPaths = false;
 
         public LayoutRuleData PrimaryData
         {
@@ -50,19 +49,6 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
 
                 validation = value;
                 Save(true);
-            }
-        }
-
-        public bool SortByAssetPaths
-        {
-            get => sortByAssetPaths;
-            set
-            {
-                if (value == sortByAssetPaths)
-                    return;
-
-                sortByAssetPaths = value;
-                Save(true);    
             }
         }
 

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
@@ -82,13 +82,6 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
                         projectSettings.ValidationSettings = new SmartAddresserProjectSettings.Validation(duplicateAddresses,
                             duplicateAssetPaths, entryHasMultipleVersions);
                 }
-
-                using (var ccs = new EditorGUI.ChangeCheckScope())
-                {
-                    var sortByAssetPaths = EditorGUILayout.Toggle("Sort by assetPaths", projectSettings.SortByAssetPaths);
-                    if (ccs.changed)
-                        projectSettings.SortByAssetPaths = sortByAssetPaths;
-                }
             }
         }
 

--- a/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using UnityEditor;
 
 namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
@@ -8,9 +7,8 @@ namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
     {
         public string[] GetAllAssetPaths()
         {
-            var allAssetPaths = AssetDatabase.GetAllAssetPaths().ToList();
-            allAssetPaths = allAssetPaths.OrderBy(a => Guid.NewGuid()).ToList();
-            return allAssetPaths.ToArray();
+            var allAssetPaths = AssetDatabase.GetAllAssetPaths();
+            return allAssetPaths;
         }
 
         public string GUIDToAssetPath(string guid)

--- a/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AssetDatabaseAdapter/AssetDatabaseAdapter.cs
@@ -1,5 +1,5 @@
 using System;
-using SmartAddresser.Editor.Core.Tools.Shared;
+using System.Linq;
 using UnityEditor;
 
 namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
@@ -8,14 +8,9 @@ namespace SmartAddresser.Editor.Foundation.AssetDatabaseAdapter
     {
         public string[] GetAllAssetPaths()
         {
-            string[] allAssetPaths = AssetDatabase.GetAllAssetPaths();
-            var projectSettings = SmartAddresserProjectSettings.instance;
-            if (projectSettings == null || !projectSettings.SortByAssetPaths)
-            {
-                return allAssetPaths;
-            }
-            Array.Sort(allAssetPaths, StringComparer.OrdinalIgnoreCase);
-            return allAssetPaths;
+            var allAssetPaths = AssetDatabase.GetAllAssetPaths().ToList();
+            allAssetPaths = allAssetPaths.OrderBy(a => Guid.NewGuid()).ToList();
+            return allAssetPaths.ToArray();
         }
 
         public string GUIDToAssetPath(string guid)


### PR DESCRIPTION
既存エントリの順番を保持する形でApplyを行うように修正しました。

Related Issue: https://github.com/CyberAgentGameEntertainment/SmartAddresser/issues/49

## 経緯
* 上記のIssueに対して、以下のPRをマージした
    * https://github.com/CyberAgentGameEntertainment/SmartAddresser/pull/48
* この実装だと全てのアセットに対して適用する際にはパスの順にソートされるのに、個別のアセットに対して適用した場合（新しくアセットを作った場合）には末尾に追加されてしまう
    * その後全てのアセットに対して適用すると、やはり順番が変わってしまう
* そのためソートをやめて既存の順番を保持する実装に変更しました
