### PR TITLE
Ignore classes derived from `AssetFilterAsset` in adding asset filter menu

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetGroupPanelPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetGroupPanelPresenter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using SmartAddresser.Editor.Core.Models.Shared.AssetGroups;
+using SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl;
 using SmartAddresser.Editor.Foundation.CommandBasedUndo;
 using SmartAddresser.Editor.Foundation.TinyRx;
 using UnityEditor;
@@ -228,6 +229,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
                 // Get types of all asset filter.
                 var types = TypeCache.GetTypesDerivedFrom<IAssetFilter>()
                     .Where(x => !x.IsAbstract)
+                    .Where(x => !typeof(AssetFilterAsset).IsAssignableFrom(x))
                     .Where(x => x.GetCustomAttribute<IgnoreAssetFilterAttribute>() == null);
 
                 // Show filter selection menu.


### PR DESCRIPTION
## 概要

アセットフィルタの追加メニューにおいて、`AssetFilterAsset`を継承して実装されたカスタムのアセットフィルタを表示しないようにします。

## 詳細

`AssetFilterAsset`を継承してカスタムのアセットフィルタを実装すると、アセットフィルタを追加する際のメニューに項目が追加されますが、こちらを選ぶと例外が発生しアセットフィルタの追加ができませんでした。

<img width="514" alt="image" src="https://github.com/CyberAgentGameEntertainment/SmartAddresser/assets/16096562/6d3ac1e8-6e35-4b07-8373-2dd29908c0cb">

```
InvalidOperationException: Operation is not valid due to the current state of the object.
SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl.AssetFilterAsset.SmartAddresser.Editor.Core.Models.Shared.AssetGroups.IAssetFilter.get_Id () (at Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/AssetFilterAsset.cs:8)
SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups.AssetGroupPanelPresenter+<>c__DisplayClass13_4.<SetupViewEventHandlers>b__27 () (at Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetGroupPanelPresenter.cs:244)
UnityEditor.GenericMenu.CatchMenu (System.Object userData, System.String[] options, System.Int32 selected) (at /Users/bokken/build/output/unity/unity/Editor/Mono/GUI/GenericMenu.cs:127)
```

READMEでは、直接カスタムアセットフィルタを追加するのではなく、`CustomAssetFilter`を追加してからそこにScirptableObjectとしてアサインするようになっていて、こちらの手順は正しく機能します。

このPRでは、`AssetFilterAsset`の派生クラスはアセットフィルタの追加メニューに表示しないようにして、上記手順で混乱するのを防止します。