### PR TITLE
Fix crash in `InvokeBatchModificationEvent`

### DIFF
--- a/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs
@@ -49,7 +49,7 @@ namespace SmartAddresser.Editor.Foundation.AddressableAdapter
 
         public void InvokeBatchModificationEvent()
         {
-            _settings.OnModification.Invoke(_settings,
+            _settings.OnModification?.Invoke(_settings,
                 AddressableAssetSettings.ModificationEvent.BatchModification,
                 null);
         }


### PR DESCRIPTION
Found the following crash while testing in Unity 6' latest preview :

```
NullReferenceException: Object reference not set to an instance of an object
SmartAddresser.Editor.Foundation.AddressableAdapter.AddressableAssetSettingsAdapter.InvokeBatchModificationEvent () (at ./Library/PackageCache/jp.co.cyberagent.smartaddresser/Editor/Foundation/AddressableAdapter/AddresableAssetSettingsAdapter.cs:53)
SmartAddresser.Editor.Core.Models.Services.ApplyLayoutRuleService.InvokeBatchModificationEvent () (at ./Library/PackageCache/jp.co.cyberagent.smartaddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs:184)
SmartAddresser.Editor.Core.Tools.Importer.SmartAddresserAssetPostProcessor.OnPostprocessAllAssets (System.String[] importedAssetPaths, System.String[] deletedAssetPaths, System.String[] movedAssetPaths, System.String[] movedFromAssetPaths) (at ./Library/PackageCache/jp.co.cyberagent.smartaddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs:48)
System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <321eb2db7c6d43ea8fc39b54eaca3452>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <321eb2db7c6d43ea8fc39b54eaca3452>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <321eb2db7c6d43ea8fc39b54eaca3452>:0)
UnityEditor.AssetPostprocessingInternal.InvokeMethod (System.Reflection.MethodInfo method, System.Object[] args) (at <72fbd834e62348cf8a5f322f2740f684>:0)
UnityEditor.AssetPostprocessingInternal.PostprocessAllAssets (System.String[] importedAssets, System.String[] addedAssets, System.String[] deletedAssets, System.String[] movedAssets, System.String[] movedFromPathAssets, System.Boolean didDomainReload) (at <72fbd834e62348cf8a5f322f2740f684>:0)
UnityEditor.AssetDatabase:ImportAsset(String, ImportAssetOptions)
AddressablesPlayerBuildProcessor:PrepareForPlayerbuild(AddressableAssetSettings, BuildPlayerContext, Boolean) (at ./Library/PackageCache/com.unity.addressables/Editor/Build/AddressablesPlayerBuildProcessor.cs:121)
AddressablesPlayerBuildProcessor:PrepareForBuild(BuildPlayerContext) (at ./Library/PackageCache/com.unity.addressables/Editor/Build/AddressablesPlayerBuildProcessor.cs:79)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```

Debugging of the crash yields that `_settings` is correct, but `_settings.OnModification` is `null`. All usage I've found of `OnModification` (an `Action<T>`) will check for `null` before invoking. This is not the case here, so, if we're unlucky and no one is registered, this function will crash. Hitting this crash seems to make `Build and Run` usage also fail from what I can gather (clean build, however, worked on my end, though I am not sure why). This crash can be circumvented by registering anything to `OnModification`, so, for example, keeping the Layout Rule Editor open will do so.

To fix this, we just add a check for `null`, matching Unity's own usage.