### PR TITLE
Multiple LayoutRule can be Applied at once.

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/BaseLayoutRuleData.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/BaseLayoutRuleData.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SmartAddresser.Editor.Core.Models.LayoutRules
+{
+    public abstract class BaseLayoutRuleData : ScriptableObject
+    {
+        public abstract IEnumerable<LayoutRule> LayoutRules { get; }
+    }
+}

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/BaseLayoutRuleData.cs.meta
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/BaseLayoutRuleData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bf33a5f4581b441faa00f61e477ece35
+timeCreated: 1737623198

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleData.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleData.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace SmartAddresser.Editor.Core.Models.LayoutRules
+{
+    [CreateAssetMenu(fileName = "CompositeLayoutRuleData", menuName = "Smart Addresser/Composite Layout Rule Data")]
+    public sealed class CompositeLayoutRuleData : BaseLayoutRuleData
+    {
+        [SerializeField] private LayoutRuleData[] _layoutRules;
+
+        public override IEnumerable<LayoutRule> LayoutRules => _layoutRules.SelectMany(x => x.LayoutRules);
+    }
+}

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleData.cs.meta
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cde3853f74d44b8797e28a8e489d46a9
+timeCreated: 1737623330

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs
@@ -1,0 +1,22 @@
+using SmartAddresser.Editor.Core.Tools.Shared;
+using UnityEditor;
+using UnityEngine;
+
+namespace SmartAddresser.Editor.Core.Models.LayoutRules
+{
+    [CustomEditor(typeof(CompositeLayoutRuleData))]
+    internal sealed class CompositeLayoutRuleDataEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            var data = (CompositeLayoutRuleData)target;
+
+            if (GUILayout.Button("Apply"))
+                MenuActions.ApplyAction(data);
+
+            GUI.enabled = false;
+            base.OnInspectorGUI();
+            GUI.enabled = true;
+        }
+    }
+}

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs
@@ -14,9 +14,7 @@ namespace SmartAddresser.Editor.Core.Models.LayoutRules
             if (GUILayout.Button("Apply"))
                 MenuActions.ApplyAction(data);
 
-            GUI.enabled = false;
             base.OnInspectorGUI();
-            GUI.enabled = true;
         }
     }
 }

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs.meta
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/CompositeLayoutRuleDataEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6f5b3a0734cf43fb8e22d00343336e2a
+timeCreated: 1738056790

--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/LayoutRuleData.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/LayoutRuleData.cs
@@ -1,9 +1,10 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Models.LayoutRules
 {
     [CreateAssetMenu(fileName = "LayoutRuleData", menuName = "Smart Addresser/Layout Rule Data")]
-    public sealed class LayoutRuleData : ScriptableObject
+    public sealed class LayoutRuleData : BaseLayoutRuleData
     {
         [SerializeField] private LayoutRule _layoutRule = new LayoutRule();
 
@@ -11,6 +12,11 @@ namespace SmartAddresser.Editor.Core.Models.LayoutRules
         {
             get => _layoutRule;
             set => _layoutRule = value;
+        }
+
+        public override IEnumerable<LayoutRule> LayoutRules
+        {
+            get { yield return _layoutRule; }
         }
     }
 }

--- a/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Services/ApplyLayoutRuleService.cs
@@ -78,9 +78,9 @@ namespace SmartAddresser.Editor.Core.Models.Services
             _addressableSettingsAdapter.InvokeBatchModificationEvent();
         }
 
-        public void Apply(string assetGuid, bool doSetup, bool invokeModificationEvent, string versionExpression = null)
+        public void Apply(string assetGuid, bool doSetup, bool invokeModificationEvent)
         {
-            var result = _layoutRules.Any(x => TryAddEntry(x, assetGuid, doSetup, false, versionExpression));
+            var result = _layoutRules.Any(x => TryAddEntry(x, assetGuid, doSetup, false, x.Settings.VersionExpression.Value));
 
             // If the address is not assigned by the LayoutRule and the entry belongs to the AddressableGroup under Control, remove the entry.
             var controlGroupNames = _layoutRules

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
@@ -249,56 +249,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
 
                 menu.AddItem(new GUIContent("Apply to Addressables"),
                     false,
-                    () =>
-                    {
-                        var projectSettings = SmartAddresserProjectSettings.instance;
-                        var primaryData = projectSettings.PrimaryData;
-
-                        if (primaryData == null)
-                        {
-                            Apply();
-                            return;
-                        }
-
-                        if (primaryData == _editingData.Value)
-                        {
-                            Apply();
-                            return;
-                        }
-
-                        // If the primary data is not the same as the editing data, ask the user to confirm.
-                        // If the user confirms, remove the primary data and apply the editing data.
-                        var dialogMessage =
-                            $"The {nameof(projectSettings.PrimaryData)} of the Project Settings is not the same as the data you are applying. Do you want to remove the {nameof(projectSettings.PrimaryData)} from Project Settings and apply the editing data?";
-                        if (EditorUtility.DisplayDialog("Confirm", dialogMessage, "Remove & Apply", "Cancel"))
-                        {
-                            projectSettings.PrimaryData = null;
-                            Apply();
-                        }
-
-                        void Apply()
-                        {
-                            var layoutRule = _editingData.Value.LayoutRule;
-                            layoutRule.Setup();
-                            
-                            // Validate the layout rule.
-                            var validateService = new ValidateAndExportLayoutRuleService(layoutRule);
-                            var ruleErrorHandleType = projectSettings.LayoutRuleErrorSettings.HandleType;
-                            validateService.Execute(false, ruleErrorHandleType, out _);
-                            
-                            // Apply the layout rules to the addressable asset system.
-                            var versionExpressionParser = new VersionExpressionParserRepository().Load();
-                            var assetDatabaseAdapter = new AssetDatabaseAdapter();
-                            var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
-                            var addressableSettingsAdapter = new AddressableAssetSettingsAdapter(addressableSettings);
-                            var applyService = new ApplyLayoutRuleService(layoutRule,
-                                versionExpressionParser,
-                                addressableSettingsAdapter,
-                                assetDatabaseAdapter);
-
-                            applyService.ApplyAll(false);
-                        }
-                    });
+                    () => MenuActions.ApplyAction(_editingData.Value));
 
                 menu.AddItem(new GUIContent("Open Layout Viewer"), false, LayoutViewerWindow.Open);
 

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorWindow.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorWindow.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using SmartAddresser.Editor.Core.Models.Services;
 using SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.AddressRuleEditor;
 using SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.LabelRuleEditor;
@@ -74,20 +75,19 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
                 var primaryData = projectSettings.PrimaryData;
                 if (primaryData != null)
                 {
-                    var layoutRule = primaryData.LayoutRule;
-                    layoutRule.Setup();
+                    var layoutRules = primaryData.LayoutRules.ToArray();
 
                     // Validate the layout rule.
-                    var validateService = new ValidateAndExportLayoutRuleService(layoutRule);
+                    var validateService = new ValidateAndExportLayoutRuleService(layoutRules);
                     var ruleErrorHandleType = projectSettings.LayoutRuleErrorSettings.HandleType;
-                    validateService.Execute(false, ruleErrorHandleType, out _);
+                    validateService.Execute(true, ruleErrorHandleType, out _);
 
                     // Apply the layout rule to the addressable asset system.
                     var versionExpressionParser = new VersionExpressionParserRepository().Load();
                     var assetDatabaseAdapter = new AssetDatabaseAdapter();
                     var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
                     var addressableSettingsAdapter = new AddressableAssetSettingsAdapter(addressableSettings);
-                    var applyService = new ApplyLayoutRuleService(layoutRule,
+                    var applyService = new ApplyLayoutRuleService(layoutRules,
                         versionExpressionParser,
                         addressableSettingsAdapter,
                         assetDatabaseAdapter);

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/LayoutRuleDataRepository.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/LayoutRuleDataRepository.cs
@@ -9,7 +9,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared
 {
     public sealed class LayoutRuleDataRepository : ILayoutRuleDataRepository
     {
-        public LayoutRuleData PrimaryData => SmartAddresserProjectSettings.instance.PrimaryData;
+        public BaseLayoutRuleData PrimaryData => SmartAddresserProjectSettings.instance.PrimaryData;
 
         public IReadOnlyObservableProperty<LayoutRuleData> EditingData =>
             SmartAddresserPreferences.instance.EditingData;

--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -54,23 +54,16 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
             validateLayoutRuleService.Execute(false, layoutRuleErrorHandleType, out _);
 
             // Apply
-            foreach (var layoutRule in layoutRules)
+            foreach (var importedAssetPath in importedAssetPaths)
             {
-                var versionExpression = layoutRule.Settings.VersionExpression.Value;
-                if (string.IsNullOrEmpty(versionExpression))
-                    versionExpression = null;
+                var guid = AssetDatabase.AssetPathToGUID(importedAssetPath);
+                applyService.Apply(guid, false, true);
+            }
 
-                foreach (var importedAssetPath in importedAssetPaths)
-                {
-                    var guid = AssetDatabase.AssetPathToGUID(importedAssetPath);
-                    applyService.Apply(guid, false, true, versionExpression);
-                }
-
-                foreach (var movedAssetPath in movedAssetPaths)
-                {
-                    var guid = AssetDatabase.AssetPathToGUID(movedAssetPath);
-                    applyService.Apply(guid, false, true, versionExpression);
-                }
+            foreach (var movedAssetPath in movedAssetPaths)
+            {
+                var guid = AssetDatabase.AssetPathToGUID(movedAssetPath);
+                applyService.Apply(guid, false, true);
             }
 
             applyService.InvokeBatchModificationEvent();

--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -35,17 +35,18 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
             if (primaryData == null)
                 return;
 
-            var layoutRule = layoutRuleDataRepository.PrimaryData.LayoutRule;
+            var layoutRules = layoutRuleDataRepository.PrimaryData.LayoutRules.ToArray();
             var versionExpressionParser = new VersionExpressionParserRepository().Load();
             var assetDatabaseAdapter = new AssetDatabaseAdapter();
             var addressableSettingsAdapter = new AddressableAssetSettingsAdapter(addressableSettings);
-            var applyService = new ApplyLayoutRuleService(layoutRule,
-                versionExpressionParser,
-                addressableSettingsAdapter,
-                assetDatabaseAdapter);
-            var validateLayoutRuleService = new ValidateAndExportLayoutRuleService(layoutRule);
+            var applyService = new ApplyLayoutRuleService(layoutRules,
+                                                          versionExpressionParser,
+                                                          addressableSettingsAdapter,
+                                                          assetDatabaseAdapter);
+            var validateLayoutRuleService = new ValidateAndExportLayoutRuleService(layoutRules);
 
-            layoutRule.Setup();
+            foreach (var layoutRule in layoutRules)
+                layoutRule.Setup();
 
             // Check Layout Rule corruption
             var projectSettings = SmartAddresserProjectSettings.instance;
@@ -53,20 +54,23 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
             validateLayoutRuleService.Execute(false, layoutRuleErrorHandleType, out _);
 
             // Apply
-            var versionExpression = layoutRule.Settings.VersionExpression.Value;
-            if (string.IsNullOrEmpty(versionExpression))
-                versionExpression = null;
-
-            foreach (var importedAssetPath in importedAssetPaths)
+            foreach (var layoutRule in layoutRules)
             {
-                var guid = AssetDatabase.AssetPathToGUID(importedAssetPath);
-                applyService.Apply(guid, false, true, versionExpression);
-            }
+                var versionExpression = layoutRule.Settings.VersionExpression.Value;
+                if (string.IsNullOrEmpty(versionExpression))
+                    versionExpression = null;
 
-            foreach (var movedAssetPath in movedAssetPaths)
-            {
-                var guid = AssetDatabase.AssetPathToGUID(movedAssetPath);
-                applyService.Apply(guid, false, true, versionExpression);
+                foreach (var importedAssetPath in importedAssetPaths)
+                {
+                    var guid = AssetDatabase.AssetPathToGUID(importedAssetPath);
+                    applyService.Apply(guid, false, true, versionExpression);
+                }
+
+                foreach (var movedAssetPath in movedAssetPaths)
+                {
+                    var guid = AssetDatabase.AssetPathToGUID(movedAssetPath);
+                    applyService.Apply(guid, false, true, versionExpression);
+                }
             }
 
             applyService.InvokeBatchModificationEvent();

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/MenuActions.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/MenuActions.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using SmartAddresser.Editor.Core.Models.LayoutRules;
+using SmartAddresser.Editor.Core.Models.Services;
+using SmartAddresser.Editor.Foundation.AddressableAdapter;
+using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
+using UnityEditor;
+using UnityEditor.AddressableAssets;
+
+namespace SmartAddresser.Editor.Core.Tools.Shared
+{
+    internal static class MenuActions
+    {
+        public static void ApplyAction(BaseLayoutRuleData target)
+        {
+            var projectSettings = SmartAddresserProjectSettings.instance;
+            var primaryData = projectSettings.PrimaryData;
+
+            if (primaryData == null)
+            {
+                Apply();
+                return;
+            }
+
+            if (primaryData == target)
+            {
+                Apply();
+                return;
+            }
+
+            // If the primary data is not the same as the editing data, ask the user to confirm.
+            // If the user confirms, remove the primary data and apply the editing data.
+            var dialogMessage =
+                $"The {nameof(projectSettings.PrimaryData)} of the Project Settings is not the same as the data you are applying. Do you want to remove the {nameof(projectSettings.PrimaryData)} from Project Settings and apply the editing data?";
+            if (EditorUtility.DisplayDialog("Confirm", dialogMessage, "Remove & Apply", "Cancel"))
+            {
+                projectSettings.PrimaryData = null;
+                Apply();
+            }
+
+            return;
+
+            void Apply()
+            {
+                var layoutRules = target.LayoutRules.ToArray();
+
+                foreach (var layoutRule in layoutRules)
+                    layoutRule.Setup();
+
+                // Validate the layout rule.
+                var validateService = new ValidateAndExportLayoutRuleService(layoutRules);
+                var ruleErrorHandleType = projectSettings.LayoutRuleErrorSettings.HandleType;
+                validateService.Execute(false, ruleErrorHandleType, out _);
+
+                // Apply the layout rules to the addressable asset system.
+                var versionExpressionParser = new VersionExpressionParserRepository().Load();
+                var assetDatabaseAdapter = new AssetDatabaseAdapter();
+                var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
+                var addressableSettingsAdapter = new AddressableAssetSettingsAdapter(addressableSettings);
+                var applyService = new ApplyLayoutRuleService(layoutRules,
+                                                              versionExpressionParser,
+                                                              addressableSettingsAdapter,
+                                                              assetDatabaseAdapter);
+
+                applyService.ApplyAll(false);
+            }
+        }
+    }
+}

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/MenuActions.cs.meta
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/MenuActions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: de07a178e76041e7b0ce61feceb03685
+timeCreated: 1738057815

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettings.cs
@@ -9,12 +9,12 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
     [FilePath("Smart Addresser/SmartAddresserSettings.asset", FilePathAttribute.Location.ProjectFolder)]
     public sealed class SmartAddresserProjectSettings : ScriptableSingleton<SmartAddresserProjectSettings>
     {
-        [SerializeField] private LayoutRuleData primaryData;
+        [SerializeField] private BaseLayoutRuleData primaryData;
         [SerializeField] private MonoScript versionExpressionParser;
         [SerializeField] private Validation validation = new Validation();
         [SerializeField] private LayoutRuleError layoutRuleError = new LayoutRuleError();
 
-        public LayoutRuleData PrimaryData
+        public BaseLayoutRuleData PrimaryData
         {
             get => primaryData;
             set

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
@@ -36,10 +36,10 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
                 {
                     var oldData = projectSettings.PrimaryData;
                     projectSettings.PrimaryData =
-                        (LayoutRuleData)EditorGUILayout.ObjectField("Primary Data",
-                            projectSettings.PrimaryData,
-                            typeof(LayoutRuleData),
-                            false);
+                        (BaseLayoutRuleData)EditorGUILayout.ObjectField("Primary Data",
+                                                                        projectSettings.PrimaryData,
+                                                                        typeof(BaseLayoutRuleData),
+                                                                        false);
 
                     if (ccs.changed && projectSettings.PrimaryData != null)
                     {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/SmartAddresserProjectSettingsProvider.cs
@@ -48,8 +48,8 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
                             "OK",
                             "Cancel"))
                         {
-                            var layoutRule = projectSettings.PrimaryData.LayoutRule;
-                            var validateService = new ValidateAndExportLayoutRuleService(layoutRule);
+                            var layoutRules = projectSettings.PrimaryData.LayoutRules;
+                            var validateService = new ValidateAndExportLayoutRuleService(layoutRules);
 
                             // Check Corruption
                             var corruptionNotificationType =

--- a/Assets/SmartAddresser/Editor/Core/Tools/Shared/ValidateAndExportLayoutRuleService.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Shared/ValidateAndExportLayoutRuleService.cs
@@ -3,6 +3,9 @@
 // --------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using SmartAddresser.Editor.Core.Models.LayoutRules;
 using SmartAddresser.Editor.Core.Models.Services;
 using SmartAddresser.Editor.Core.Models.Shared.AssetGroups.ValidationError;
@@ -16,35 +19,51 @@ namespace SmartAddresser.Editor.Core.Tools.Shared
         private readonly string _exportFilePath;
 
         private readonly ExportLayoutRuleValidationErrorService _exportService;
-        private readonly ValidateLayoutRuleService _validateService;
+        private readonly ValidateLayoutRuleService[] _validateServices;
 
-        public ValidateAndExportLayoutRuleService(LayoutRule layoutRule, string overrideExportFilePath = null)
+        public ValidateAndExportLayoutRuleService(LayoutRule layoutRule, string overrideExportFilePath = null) :
+            this(new[] { layoutRule }, overrideExportFilePath)
         {
-            _validateService = new ValidateLayoutRuleService(layoutRule);
+        }
+
+        public ValidateAndExportLayoutRuleService(IEnumerable<LayoutRule> layoutRules,
+                                                  string overrideExportFilePath = null)
+        {
+            _validateServices = layoutRules.Select(rule => new ValidateLayoutRuleService(rule)).ToArray();
             _exportService = new ExportLayoutRuleValidationErrorService();
             _exportFilePath = string.IsNullOrEmpty(overrideExportFilePath)
-                ? DefaultExportFilePath
-                : overrideExportFilePath;
+                                  ? DefaultExportFilePath
+                                  : overrideExportFilePath;
         }
 
         public bool Execute(
             bool doSetup,
             LayoutRuleErrorHandleType handleType,
-            out LayoutRuleValidationError error
+            out List<LayoutRuleValidationError> errorList
         )
         {
+            errorList = new List<LayoutRuleValidationError>(_validateServices.Length);
+
             if (handleType == LayoutRuleErrorHandleType.Ignore)
-            {
-                error = null;
                 return false;
-            }
 
             // Validate
-            if (_validateService.Execute(doSetup, out error))
-                return true;
+            var exportFileName = Path.GetFileNameWithoutExtension(_exportFilePath);
+            var exportFileExtension = Path.GetExtension(_exportFilePath);
+            for (var i = 0; i < _validateServices.Length; i++)
+            {
+                var validateService = _validateServices[i];
+                if (validateService.Execute(doSetup, out var error))
+                    continue;
 
-            // Export
-            _exportService.Run(error, _exportFilePath);
+                errorList.Add(error);
+                // Export
+                var exportFilePath = $"{exportFileName}_{i}{exportFileExtension}";
+                _exportService.Run(error, exportFilePath);
+            }
+
+            if (errorList.Count == 0)
+                return true;
 
             // Log / Exception
             var message =

--- a/Assets/SmartAddresser/Tests/Editor/Core/Models/Services/ApplyLayoutRuleServiceTest.cs
+++ b/Assets/SmartAddresser/Tests/Editor/Core/Models/Services/ApplyLayoutRuleServiceTest.cs
@@ -185,7 +185,8 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var layoutRule = CreateLayoutRule(TestAddressableGroupName,
                 TestAssetPath,
                 PartialAssetPathType.FileName,
-                version: "1.2.3");
+                version: "1.2.3",
+                versionExpression: "[1.2.3,1.2.4)");
             var assetDatabaseAdapter =
                 CreateSingleEntryAssetDatabaseAdapter(assetGuid, TestAssetPath, assetType, isFolder);
             var addressableSettingsAdapter = new FakeAddressableAssetSettingsAdapter();
@@ -194,7 +195,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
                 addressableSettingsAdapter,
                 assetDatabaseAdapter);
 
-            service.Apply(assetGuid, true, false, "[1.2.3,1.2.4)");
+            service.Apply(assetGuid, true, false);
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(assetEntry, Is.Not.Null);
             Assert.That(assetEntry.GroupName, Is.EqualTo(TestAddressableGroupName));
@@ -211,7 +212,8 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var layoutRule = CreateLayoutRule(TestAddressableGroupName,
                 TestAssetPath,
                 PartialAssetPathType.FileName,
-                version: "1.2.3");
+                version: "1.2.3",
+                versionExpression: "(1.2.3,1.3)");
             var assetDatabaseAdapter =
                 CreateSingleEntryAssetDatabaseAdapter(assetGuid, TestAssetPath, assetType, isFolder);
             var addressableSettingsAdapter = new FakeAddressableAssetSettingsAdapter();
@@ -220,7 +222,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
                 addressableSettingsAdapter,
                 assetDatabaseAdapter);
 
-            service.Apply(assetGuid, true, false, "(1.2.3,1.3)");
+            service.Apply(assetGuid, true, false);
             var assetEntry = addressableSettingsAdapter.FindAssetEntry(assetGuid);
             Assert.That(assetEntry, Is.Null);
         }
@@ -235,7 +237,8 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             var layoutRule = CreateLayoutRule(TestAddressableGroupName,
                 TestAssetPath,
                 PartialAssetPathType.FileName,
-                version: "1.2.3");
+                version: "1.2.3",
+                versionExpression:"(1.2.3, 1.3)");
             var assetDatabaseAdapter =
                 CreateSingleEntryAssetDatabaseAdapter(assetGuid, TestAssetPath, assetType, isFolder);
             var addressableSettingsAdapter = new FakeAddressableAssetSettingsAdapter();
@@ -244,7 +247,7 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
                 addressableSettingsAdapter,
                 assetDatabaseAdapter);
 
-            Assert.That(() => service.Apply(assetGuid, true, false, "(1.2.3, 1.3)"), Throws.InstanceOf<Exception>());
+            Assert.That(() => service.Apply(assetGuid, true, false), Throws.InstanceOf<Exception>());
         }
 
         [Test]
@@ -292,12 +295,14 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             string regexAssetPathFilter,
             PartialAssetPathType addressProvideMode,
             string label = null,
-            string version = null
+            string version = null,
+            string versionExpression = null
         )
         {
             var addressableGroup = ScriptableObject.CreateInstance<AddressableAssetGroup>();
             addressableGroup.Name = addressableGroupName;
-            return CreateLayoutRule(addressableGroup, regexAssetPathFilter, addressProvideMode, label, version);
+            return CreateLayoutRule(addressableGroup, regexAssetPathFilter, addressProvideMode, label, version,
+                                    versionExpression);
         }
 
         private static LayoutRule CreateLayoutRule(
@@ -305,7 +310,8 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
             string regexAssetPathFilter,
             PartialAssetPathType addressProvideMode,
             string label = null,
-            string version = null
+            string version = null,
+            string versionExpression = null
         )
         {
             var assetFilter = new RegexBasedAssetFilter
@@ -356,6 +362,8 @@ namespace SmartAddresser.Tests.Editor.Core.Models.Services
                 versionRule.AssetGroups.Add(assetGroup);
                 layoutRule.VersionRules.Add(versionRule);
             }
+
+            layoutRule.Settings.VersionExpression.Value = versionExpression;
 
             return layoutRule;
         }


### PR DESCRIPTION
#65 

解決策として書かれていた `CompositeLayoutRuleData` という形で試行中

- 既定クラスとして `BaseLayoutRuleData` を実装
- 既存クラスの `LayoutRuleData` を `BaseLayoutRuleData` を継承する形に変更
- 新規クラスとして `CompositeLayoutRuleData` を `BaseLayoutRuleData` を継承する形で実装
- `CompositeLayoutRuleData` のインスペクタに Applyボタンを配置 (エディタのメニューから行うものと同一挙動)
- バリデーションはエラー発生時中断ではなく、一連のLayoutRuleDataを処理するまで実行する形式
  - エラーがあった場合、指定されたファイル名の末尾に _[番号] を付加する (xxx.jsonの場合 xxx_1.json, xxx_3.json のような形)
- 【要確認】ApplyLayoutRuleServiceのApply関数のインタフェースを変えている
- 【要確認】複数のLayoutRuleDataで矛盾が生じる場合にどうするか

確認事項

- [x] 旧バージョンで設定したPrimaryDataの参照が維持される
- [x] 旧バージョンで作成したLayoutRuleDataを読み込むことができる
- [x] エディタのLayoutRuleData選択プルダウンにCompositeLayoutRuleDataは含まれない
- [x] CompositeLayoutRuleDataのインスペクタにて既存のLayoutRuleDataを複数登録できる
- [x] CompositeLayoutRuleDataのインスペクタからApplyできる (PrimaryDataが設定されている場合nullにする確認ダイアログが開く) 
- [x] 既存のLayoutRuleDataのApplyがデグレしていない
- [x] CompositeLayoutRuleDataのApplyで複数のLayoutRuleDataを加算した結果になる
- [x] 既存のテストがすべて正常通過する
- [x] ProjectSettingsのPrimaryData欄にLayoutRuleDataとCompositeLayoutRuleData双方が設定できる