### PR TITLE
Make it easier to reorder AssetGroup and AssetFilter.

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetFilterView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetFilterView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using SmartAddresser.Editor.Core.Models.Shared.AssetGroups;
 using SmartAddresser.Editor.Foundation.CustomDrawers;
@@ -15,16 +16,20 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
     {
         private const string RemoveMenuName = "Remove Filter";
         private const string MoveUpMenuName = "Move Up Filter";
+        private const string MoveUpByMenuName = "Move Up Filter By";
         private const string PasteMenuName = "Paste Filter As New";
         private const string PasteValuesMenuName = "Paste Filter Values";
         private const string MoveDownMenuName = "Move Down Filter";
+        private const string MoveDownByMenuName = "Move Down Filter By";
         private const string CopyMenuName = "Copy Filter";
 
         private readonly Subject<Empty> _copyMenuExecutedSubject = new Subject<Empty>();
         private readonly ICustomDrawer _drawer;
         private readonly Subject<Empty> _mouseButtonClickedSubject = new Subject<Empty>();
         private readonly Subject<Empty> _moveDownMenuExecutedSubject = new Subject<Empty>();
+        private readonly Subject<int>  _moveDownByMenuExecutedSubject = new Subject<int>();
         private readonly Subject<Empty> _moveUpMenuExecutedSubject = new Subject<Empty>();
+        private readonly Subject<int>  _moveUpByMenuExecutedSubject = new Subject<int>();
         private readonly Subject<Empty> _pasteMenuExecutedSubject = new Subject<Empty>();
         private readonly Subject<Empty> _pasteValuesMenuExecutedSubject = new Subject<Empty>();
         private readonly Subject<Empty> _removeMenuExecutedSubject = new Subject<Empty>();
@@ -49,7 +54,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
 
         public IObservable<Empty> RemoveMenuExecutedAsObservable => _removeMenuExecutedSubject;
         public IObservable<Empty> MoveUpMenuExecutedAsObservable => _moveUpMenuExecutedSubject;
+        public IObservable<int> MoveUpByMenuExecutedAsObservable => _moveUpByMenuExecutedSubject;
         public IObservable<Empty> MoveDownMenuExecutedAsObservable => _moveDownMenuExecutedSubject;
+        public IObservable<int> MoveDownByMenuExecutedAsObservable => _moveDownByMenuExecutedSubject;
         public IObservable<Empty> ValueChangedAsObservable => _valueChangedSubject;
         public IObservable<Empty> CopyMenuExecutedAsObservable => _copyMenuExecutedSubject;
         public IObservable<Empty> PasteMenuExecutedSubject => _pasteMenuExecutedSubject;
@@ -70,6 +77,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
 
         public event Func<bool> CanPaste;
         public event Func<bool> CanPasteValues;
+
+        public event Func<ICollection<int>> GetMoveUpByOptions;
+        public event Func<ICollection<int>> GetMoveDownByOptions;       
 
         public void DoLayout()
         {
@@ -115,8 +125,26 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
                     () => _removeMenuExecutedSubject.OnNext(Empty.Default));
                 menu.AddItem(new GUIContent(MoveUpMenuName), false,
                     () => _moveUpMenuExecutedSubject.OnNext(Empty.Default));
+
+                var moveUpByList = GetMoveUpByOptions?.Invoke();
+                if (moveUpByList == null || moveUpByList.Count == 0)
+                    menu.AddDisabledItem(new GUIContent(MoveUpByMenuName), false);
+                else
+                    foreach (var count in moveUpByList)
+                        menu.AddItem(new GUIContent($"{MoveUpByMenuName}/{count}"), false,
+                                     () => _moveUpByMenuExecutedSubject.OnNext(count));
+
                 menu.AddItem(new GUIContent(MoveDownMenuName), false,
                     () => _moveDownMenuExecutedSubject.OnNext(Empty.Default));
+
+                var moveDownByList = GetMoveDownByOptions?.Invoke();
+                if (moveDownByList == null || moveDownByList.Count == 0)
+                    menu.AddDisabledItem(new GUIContent(MoveDownByMenuName), false);
+                else
+                    foreach (var count in moveDownByList)
+                        menu.AddItem(new GUIContent($"{MoveDownByMenuName}/{count}"), false,
+                                     () => _moveDownByMenuExecutedSubject.OnNext(count));
+
                 menu.AddItem(new GUIContent(CopyMenuName), false,
                     () => _copyMenuExecutedSubject.OnNext(Empty.Default));
 

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetGroupPanelView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/Shared/AssetGroups/AssetGroupPanelView.cs
@@ -18,7 +18,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
         private const string RenameMenuName = "Rename";
         private const string RemoveMenuName = "Remove";
         private const string MoveUpMenuName = "Move Up";
+        private const string MoveUpByMenuName = "Move Up By";
         private const string MoveDownMenuName = "Move Down";
+        private const string MoveDownByMenuName = "Move Down By";
         private const string CopyMenuName = "Copy";
         private const string PasteMenuName = "Paste As New";
         private const string PasteValuesMenuName = "Paste Values";
@@ -32,7 +34,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
         private readonly List<string> _filterViewsOrder = new List<string>();
 
         private readonly Subject<Empty> _moveDownMenuExecutedSubject = new Subject<Empty>();
+        private readonly Subject<int> _moveDownByMenuExecutedSubject = new Subject<int>();
         private readonly Subject<Empty> _moveUpMenuExecutedSubject = new Subject<Empty>();
+        private readonly Subject<int> _moveUpByMenuExecutedSubject = new Subject<int>();
         private readonly Subject<string> _nameChangedSubject = new Subject<string>();
         private readonly Subject<Empty> _pasteFilterMenuExecutedSubject = new Subject<Empty>();
         private readonly Subject<Empty> _pasteGroupMenuExecutedSubject = new Subject<Empty>();
@@ -49,7 +53,11 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
 
         public IObservable<Empty> MoveUpMenuExecutedAsObservable => _moveUpMenuExecutedSubject;
 
+        public IObservable<int> MoveUpByMenuExecutedAsObservable => _moveUpByMenuExecutedSubject;
+
         public IObservable<Empty> MoveDownMenuExecutedAsObservable => _moveDownMenuExecutedSubject;
+
+        public IObservable<int> MoveDownByMenuExecutedAsObservable => _moveDownByMenuExecutedSubject;
 
         public IObservable<Empty> CopyGroupMenuExecutedAsObservable => _copyGroupMenuExecutedSubject;
 
@@ -72,7 +80,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
             _nameChangedSubject.Dispose();
             _addFilterButtonClickedSubject.Dispose();
             _moveUpMenuExecutedSubject.Dispose();
+            _moveUpByMenuExecutedSubject.Dispose();
             _moveDownMenuExecutedSubject.Dispose();
+            _moveDownByMenuExecutedSubject.Dispose();
             _copyGroupMenuExecutedSubject.Dispose();
             _pasteGroupMenuExecutedSubject.Dispose();
             _pasteGroupValuesMenuExecutedSubject.Dispose();
@@ -83,6 +93,9 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
         public event Func<bool> CanPasteGroup;
         public event Func<bool> CanPasteGroupValues;
         public event Func<bool> CanPasteFilter;
+
+        public event Func<ICollection<int>> GetMoveUpByOptions;
+        public event Func<ICollection<int>> GetMoveDownByOptions;
 
         public AssetFilterView AddFilterView(IAssetFilter filter, int index = -1)
         {
@@ -162,9 +175,27 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.Shared.AssetGroups
                 menu.AddItem(new GUIContent(MoveUpMenuName), false,
                     () => _moveUpMenuExecutedSubject.OnNext(Empty.Default));
 
+                // Move Up By
+                var moveUpByList = GetMoveUpByOptions?.Invoke();
+                if (moveUpByList == null || moveUpByList.Count == 0)
+                    menu.AddDisabledItem(new GUIContent(MoveUpByMenuName), false);
+                else
+                    foreach (var count in moveUpByList)
+                        menu.AddItem(new GUIContent($"{MoveUpByMenuName}/{count}"), false,
+                                     () => _moveUpByMenuExecutedSubject.OnNext(count));
+
                 // Move Down
                 menu.AddItem(new GUIContent(MoveDownMenuName), false,
                     () => _moveDownMenuExecutedSubject.OnNext(Empty.Default));
+
+                // Move Down By
+                var moveDownByList = GetMoveDownByOptions?.Invoke();
+                if (moveDownByList == null || moveDownByList.Count == 0)
+                    menu.AddDisabledItem(new GUIContent(MoveDownByMenuName), false);
+                else
+                    foreach (var count in moveDownByList)
+                        menu.AddItem(new GUIContent($"{MoveDownByMenuName}/{count}"), false,
+                                     () => _moveDownByMenuExecutedSubject.OnNext(count));
 
                 // Copy Group
                 menu.AddItem(new GUIContent(CopyMenuName), false,


### PR DESCRIPTION
#64 

- AssetGroupとAssetFilterを対象に改修
- 右クリック時のメニューに「Move Up By」「Move Down By」を追加
  - 既存の「Move Up」「Move Down」とは別にする
  - 子要素として移動可能な量を表示する。index = 3の要素だとすると 1, 2, 3 の3要素
  - 移動不可能な場合は親要素である「Move Up By」または「Move Down By」自体を無効化する
- ロジックとしては Move Up は Move Up By 1、Move Down は Move Down By 1 として共通化する

確認事項

- [x] リストの先頭にある場合、Move Up By の項目が無効化される
- [x] リストの末尾にある場合、Move Down By の項目が無効化される
- [x] 要素3つの真ん中にある場合、Move Up ByおよびMove Down Byそれぞれに「1」の子要素がある
- [x] 要素4つの2つめにある場合、Move Up Byには「1」、Move Down Byには「1」「2」の子要素がある
- [x] Move Up By の移動量が指定した数値通りになる (例えば2なのに1だけ移動になったりしない)
- [x] Move Down By の移動量が指定した数値通りになる
- [x] 移動を複数回繰り返しても、移動可能量が正常に計算される