### PR TITLE
Optimize DependentObjectBasedAssetFilter by Using HashSet and Avoiding Redundant Dependency Collection

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/DependentObjectBasedAssetFilter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/DependentObjectBasedAssetFilter.cs
@@ -20,7 +20,7 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
         [SerializeField] private bool _onlyDirectDependencies;
         [SerializeField] private ObjectListableProperty _object = new ObjectListableProperty();
 
-        private List<string> _dependentAssetPaths = new List<string>();
+        private HashSet<string> _dependentAssetPaths = new HashSet<string>();
         private bool _hasNullObject;
 
         /// <summary>
@@ -50,11 +50,19 @@ namespace SmartAddresser.Editor.Core.Models.Shared.AssetGroups.AssetFilterImpl
                 }
 
                 var path = AssetDatabase.GetAssetPath(obj);
-                var dependencies = AssetDatabase.GetDependencies(path, !_onlyDirectDependencies);
-                _dependentAssetPaths.AddRange(dependencies);
-            }
 
-            _dependentAssetPaths = _dependentAssetPaths.Distinct().ToList();
+                // If we already have all the dependencies of 'path', we can skip
+                if (!_onlyDirectDependencies && _dependentAssetPaths.Contains(path) == true)
+                {
+                    continue;
+                }
+
+                var dependencies = AssetDatabase.GetDependencies(path, !_onlyDirectDependencies);
+                foreach (var dependency in dependencies)
+                {
+                    _dependentAssetPaths.Add(dependency);
+                }
+            }
         }
 
         public override bool Validate(out AssetFilterValidationError error)


### PR DESCRIPTION
This filter can get quite slow when there are thousands of assets in a project.

This change refactors DependentObjectBasedAssetFilter to improve performance and simplify logic:
	•	Replaced List<string> with HashSet<string> for _dependentAssetPaths to ensure uniqueness and provide faster lookups.
	•	Added a check to skip processing an asset if its dependencies have already been collected.
	•	Replaced AddRange with a loop to add dependencies directly to the HashSet.

This should reduce unnecessary allocations and redundant entries, especially in large asset sets, and make the filtering logic more efficient.

| Operation                        | `List<T>`                    | `HashSet<T>`                |
|----------------------------------|------------------------------|-----------------------------|
| Check if element exists (`Contains`) | O(n)       | O(1) |
| Add element                       | O(1)              | O(1)           |
| Enforce uniqueness               | Manual (`Distinct()` call, O(n log n)) | Automatic during `Add` (O(1)) |