### PR TITLE
無限インポートループの修正

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -20,6 +20,7 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
         )
         {
             var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
+            var beforeHash = addressableSettings.currentHash;
 
             // Check this because AddressableAssetSettingsDefaultObject.Settings may be null at this point when the Library folder is deleted.
             if (addressableSettings == null)
@@ -57,16 +58,19 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
             foreach (var importedAssetPath in importedAssetPaths)
             {
                 var guid = AssetDatabase.AssetPathToGUID(importedAssetPath);
-                applyService.Apply(guid, false, true);
+                applyService.Apply(guid, false, false);
             }
 
             foreach (var movedAssetPath in movedAssetPaths)
             {
                 var guid = AssetDatabase.AssetPathToGUID(movedAssetPath);
-                applyService.Apply(guid, false, true);
+                applyService.Apply(guid, false, false);
             }
 
-            applyService.InvokeBatchModificationEvent();
+            if (beforeHash != addressableSettings.currentHash)
+            {
+                applyService.InvokeBatchModificationEvent();
+            }
         }
 
         private static bool ShouldProcess(


### PR DESCRIPTION
#81 への対応

## 再現
Unity6 + AAS v2.7.2 で確認 (おそらく2.4.1以上で発生？)
AddressableAssetGroupウインドウを開いた状態で、SmartAddresserのルール適用すると発生

## 原因
AASにGroupの並び替え機能がついたのに関連して、AddressableAssetSettings.OnModificationに登録された処理からAssetDatabase.SaveAssetが呼ばれるようになった。
(AddressableAssetsSettingsGroupTreeView.SerializeState関数内)

これにより、OnPostprocessAllAssetsでルール適用時にOnModificationを呼び出すところからループが発生していた。


## 対応
ルール適用前後でAASのハッシュを比較し、変化があった場合だけOnModificationの呼び出しを行うようにした。
