### PR TITLE
AASのsortOrderをLayoutRuleEditorに反映

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
@@ -112,7 +112,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
             _assetSaveService.SetAsset(data);
 
             var groups = addressableAssetSettings.groups;
-            
+
 #if AAS_SORT_ORDER
             var orderSettings = AddressableAssetGroupSortSettings.GetSettings(addressableAssetSettings);
             groups = addressableAssetSettings.groups

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
@@ -142,11 +142,12 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
         )
         {
             if (e == AddressableAssetSettings.ModificationEvent.GroupAdded
-                || e == AddressableAssetSettings.ModificationEvent.GroupMoved
                 || e == AddressableAssetSettings.ModificationEvent.GroupRemoved
                 || e == AddressableAssetSettings.ModificationEvent.GroupRenamed)
                 // If the addressable asset group is changed, reload.
                 SetupActiveView(_editingData.Value);
+            else if (e == AddressableAssetSettings.ModificationEvent.GroupMoved)
+                EditorApplication.delayCall += () => SetupActiveView(_editingData.Value);
         }
 
         public void CleanupView()

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LayoutRuleEditorPresenter.cs
@@ -17,6 +17,7 @@ using SmartAddresser.Editor.Foundation.TinyRx.ObservableProperty;
 using UnityEditor;
 using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
 using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
@@ -110,7 +111,16 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor
             _editingData.Value = data;
             _assetSaveService.SetAsset(data);
 
-            if (data.LayoutRule.SyncAddressRulesWithAddressableAssetGroups(addressableAssetSettings.groups))
+            var groups = addressableAssetSettings.groups;
+            
+#if AAS_SORT_ORDER
+            var orderSettings = AddressableAssetGroupSortSettings.GetSettings(addressableAssetSettings);
+            groups = addressableAssetSettings.groups
+                .OrderBy(g => Array.IndexOf(orderSettings.sortOrder, g.Guid))
+                .ToList();
+#endif
+
+            if (data.LayoutRule.SyncAddressRulesWithAddressableAssetGroups(groups))
                 _assetSaveService.MarkAsDirty();
 
             _addressRuleEditorPresenter.SetupView(data.LayoutRule.AddressRules);

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
@@ -9,6 +9,8 @@ using SmartAddresser.Editor.Core.Tools.Shared;
 using SmartAddresser.Editor.Foundation.TinyRx;
 using SmartAddresser.Editor.Foundation.TinyRx.ObservableProperty;
 using UnityEditor;
+using UnityEditor.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -47,13 +49,6 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
             _editingData.Dispose();
         }
 
-        private void AddGroupView(Group group, bool reload = true)
-        {
-            _view.TreeView.AddGroup(group);
-            if (reload)
-                _view.TreeView.Reload();
-        }
-
         public void SetupView(ILayoutRuleDataRepository dataRepository)
         {
             _setupViewDisposables.Clear();
@@ -84,9 +79,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
             layout.Validate(false, validationSettings.DuplicateAddresses, validationSettings.DuplicateAssetPaths,
                 validationSettings.EntryHasMultipleVersions);
             _layout = layout;
-            foreach (var group in layout.Groups)
-                AddGroupView(group);
-            _view.TreeView.Reload();
+            ApplyGroupsToTreeView();
             _view.ActiveMode.Value = LayoutViewerView.Mode.Viewer;
             _view.ActiveAssetName.Value = data.name;
 
@@ -185,13 +178,30 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
                     validationSettings.EntryHasMultipleVersions);
                 _layout = layout;
 
-                _view.TreeView.ClearItems();
-                foreach (var group in layout.Groups)
-                    AddGroupView(group);
-                _view.TreeView.Reload();
+                ApplyGroupsToTreeView();
             }
 
             #endregion
+        }
+
+        public void ApplyGroupsToTreeView()
+        {
+            _view.TreeView.ClearItems();
+
+            if (_layout == null)
+            {
+                return;
+            }
+
+            var addressableAssetSettings = AddressableAssetSettingsDefaultObject.Settings;
+            var orderSettings = AddressableAssetGroupSortSettings.GetSettings(addressableAssetSettings);
+            foreach (var group in _layout.Groups.OrderBy(g =>
+                         Array.IndexOf(orderSettings.sortOrder, g.AddressableGroup.Guid)))
+            {
+                _view.TreeView.AddGroup(group);
+            }
+
+            _view.TreeView.Reload();
         }
 
         private void CleanupViewEventHandlers()

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerPresenter.cs
@@ -193,6 +193,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
                 return;
             }
 
+#if AAS_SORT_ORDER
             var addressableAssetSettings = AddressableAssetSettingsDefaultObject.Settings;
             var orderSettings = AddressableAssetGroupSortSettings.GetSettings(addressableAssetSettings);
             foreach (var group in _layout.Groups.OrderBy(g =>
@@ -200,6 +201,12 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
             {
                 _view.TreeView.AddGroup(group);
             }
+#else
+            foreach (var group in _layout.Groups)
+            {
+                _view.TreeView.AddGroup(group);
+            }
+#endif
 
             _view.TreeView.Reload();
         }

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerWindow.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerWindow.cs
@@ -91,15 +91,7 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
             // AssetGroupの並び順反映
             if (e == AddressableAssetSettings.ModificationEvent.GroupMoved)
             {
-                _presenter.ApplyGroupsToTreeView();
-            }
-            
-            // コールバックを末尾に登録しなおす
-            // AssetGroupの並び順はOnModificationコールバック内でシリアライズされるので、それより後に更新しないと反映できないため
-            if (_addressableAssetSettings)
-            {
-                _addressableAssetSettings.OnModification -= OnAddressableAssetSettingsModified;
-                _addressableAssetSettings.OnModification += OnAddressableAssetSettingsModified;
+                EditorApplication.delayCall += () => _presenter.ApplyGroupsToTreeView();
             }
         }
     }

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerWindow.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerWindow.cs
@@ -5,6 +5,8 @@ using SmartAddresser.Editor.Foundation.AssetDatabaseAdapter;
 using SmartAddresser.Editor.Foundation.EditorSplitView;
 using SmartAddresser.Editor.Foundation.TinyRx;
 using UnityEditor;
+using UnityEditor.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings;
 using UnityEngine;
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
@@ -21,14 +23,28 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
         private LayoutViewerPresenter _presenter;
         private LayoutViewerView _view;
 
+        private AddressableAssetSettings _addressableAssetSettings;
+
         private void OnEnable()
         {
             minSize = new Vector2(600, 200);
             Setup();
+            
+            _addressableAssetSettings = AddressableAssetSettingsDefaultObject.Settings;
+            if (_addressableAssetSettings)
+            {
+                _addressableAssetSettings.OnModification += OnAddressableAssetSettingsModified;
+            }
         }
 
         private void OnDisable()
         {
+            if (_addressableAssetSettings)
+            {
+                _addressableAssetSettings.OnModification -= OnAddressableAssetSettingsModified;
+                _addressableAssetSettings = null;
+            }
+            
             _presenter?.Dispose();
             _view?.Dispose();
         }
@@ -65,6 +81,26 @@ namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
         public static void Open()
         {
             GetWindow<LayoutViewerWindow>(WindowName);
+        }
+
+        private void OnAddressableAssetSettingsModified(
+            AddressableAssetSettings settings,
+            AddressableAssetSettings.ModificationEvent e,
+            object obj)
+        {
+            // AssetGroupの並び順反映
+            if (e == AddressableAssetSettings.ModificationEvent.GroupMoved)
+            {
+                _presenter.ApplyGroupsToTreeView();
+            }
+            
+            // コールバックを末尾に登録しなおす
+            // AssetGroupの並び順はOnModificationコールバック内でシリアライズされるので、それより後に更新しないと反映できないため
+            if (_addressableAssetSettings)
+            {
+                _addressableAssetSettings.OnModification -= OnAddressableAssetSettingsModified;
+                _addressableAssetSettings.OnModification += OnAddressableAssetSettingsModified;
+            }
         }
     }
 }

--- a/Assets/SmartAddresser/Editor/SmartAddresser.Editor.asmdef
+++ b/Assets/SmartAddresser/Editor/SmartAddresser.Editor.asmdef
@@ -15,6 +15,17 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "[1.23.1,2.0.0)",
+            "define": "AAS_SORT_ORDER"
+        },
+        {
+            "name": "com.unity.addressables",
+            "expression": "2.3.7",
+            "define": "AAS_SORT_ORDER"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
AAS側で保存されているAssetGroup並び順をLayoutRuleEditorにも反映します。

# 動作確認
AddressableAssetGroupSortSettingsが追加される境界バージョンで動作確認しました
- 1.22.3 (ない)
- 1.23.1 (ある)
- 2.3.1 (ない)
- 2.3.7 (ある)
- 2.6.0 (6000.0最新)

