### PR TITLE
fix: Addressablesの設定が未生成の場合にnull例外が発生する不具合を修正

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Importer/SmartAddresserAssetPostProcessor.cs
@@ -20,11 +20,12 @@ namespace SmartAddresser.Editor.Core.Tools.Importer
         )
         {
             var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
-            var beforeHash = addressableSettings.currentHash;
 
             // Check this because AddressableAssetSettingsDefaultObject.Settings may be null at this point when the Library folder is deleted.
             if (addressableSettings == null)
                 return;
+
+            var beforeHash = addressableSettings.currentHash;
 
             if (!ShouldProcess(importedAssetPaths, deletedAssetPaths, movedAssetPaths, movedFromAssetPaths))
                 return;


### PR DESCRIPTION
#82 の影響で発生していた不具合の修正
`addressableSettings` のnullチェック後にcurrentHashを取得することで解決 