### PR TITLE
fix: obsolete API use on Unity 6.2 or newer

### DIFF
--- a/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/LayoutRuleDataOpener.cs
+++ b/Assets/SmartAddresser/Editor/Core/Models/LayoutRules/LayoutRuleDataOpener.cs
@@ -2,15 +2,24 @@ using SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor;
 using SmartAddresser.Editor.Core.Tools.Addresser.Shared;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_6000_2_OR_NEWER
+using UnityEngine;
+#endif
 
 namespace SmartAddresser.Editor.Core.Models.LayoutRules
 {
     public static class LayoutRuleDataOpener
     {
         [OnOpenAsset(0)]
+#if UNITY_6000_2_OR_NEWER
+        public static bool OnOpen(EntityId entityId, int line)
+        {
+            var asset = EditorUtility.EntityIdToObject(entityId);
+#else
         public static bool OnOpen(int instanceID, int line)
         {
             var asset = EditorUtility.InstanceIDToObject(instanceID);
+#endif
 
             if (asset is LayoutRuleData data)
             {

--- a/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/AssetGroupBasedAssetFilterAsset.cs.meta
+++ b/Assets/SmartAddresser/Editor/Core/Models/Shared/AssetGroups/AssetFilterImpl/AssetGroupBasedAssetFilterAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e922a45dca58c54db06900c786608c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/AddressRuleEditor/AddressRuleListTreeView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/AddressRuleEditor/AddressRuleListTreeView.cs
@@ -6,6 +6,10 @@ using SmartAddresser.Editor.Foundation.EasyTreeView;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.AddressRuleEditor
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LabelRuleEditor/LabelRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LabelRuleEditor/LabelRuleEditorPresenter.cs
@@ -6,6 +6,9 @@ using SmartAddresser.Editor.Core.Tools.Addresser.Shared;
 using SmartAddresser.Editor.Foundation.CommandBasedUndo;
 using SmartAddresser.Editor.Foundation.TinyRx.ObservableCollection;
 using UnityEditor.IMGUI.Controls;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.LabelRuleEditor
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LabelRuleEditor/LabelRuleListTreeView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/LabelRuleEditor/LabelRuleListTreeView.cs
@@ -7,6 +7,10 @@ using SmartAddresser.Editor.Foundation.TinyRx;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.LabelRuleEditor
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/VersionRuleEditor/VersionRuleEditorPresenter.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/VersionRuleEditor/VersionRuleEditorPresenter.cs
@@ -6,6 +6,9 @@ using SmartAddresser.Editor.Core.Tools.Addresser.Shared;
 using SmartAddresser.Editor.Foundation.CommandBasedUndo;
 using SmartAddresser.Editor.Foundation.TinyRx.ObservableCollection;
 using UnityEditor.IMGUI.Controls;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.VersionRuleEditor
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/VersionRuleEditor/VersionRuleListTreeView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutRuleEditor/VersionRuleEditor/VersionRuleListTreeView.cs
@@ -7,6 +7,10 @@ using SmartAddresser.Editor.Foundation.TinyRx;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutRuleEditor.VersionRuleEditor
 {

--- a/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerTreeView.cs
+++ b/Assets/SmartAddresser/Editor/Core/Tools/Addresser/LayoutViewer/LayoutViewerTreeView.cs
@@ -6,6 +6,10 @@ using SmartAddresser.Editor.Foundation.EasyTreeView;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace SmartAddresser.Editor.Core.Tools.Addresser.LayoutViewer
 {

--- a/Assets/SmartAddresser/Editor/Foundation/EasyTreeView/TreeViewBase.cs
+++ b/Assets/SmartAddresser/Editor/Foundation/EasyTreeView/TreeViewBase.cs
@@ -8,6 +8,11 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace SmartAddresser.Editor.Foundation.EasyTreeView
 {


### PR DESCRIPTION
Unity 6.2 から Obsolete になって警告が出ていた API が、 Unity 6.5 beta でビルドエラーになるようになったので対処をおこないました。
エラーでの指示どおり、 Unity 6.2 以降では

- TreeView -> TreeView<int>
- TreeViewItem -> TreeViewItem<int>
- TreeViewState -> TreeViewState<int>
- InstanceIdToObject() -> EntityIdToObject()

が使用されるようにしたうえで、 LayoutRuleDataOpener.OnOpen() の引数型もそろえてあります。

お手数ですが、ご査収いただければ幸いです。